### PR TITLE
hotfix/issue#81

### DIFF
--- a/pkg/services/notification/resource_control/address_list.go
+++ b/pkg/services/notification/resource_control/address_list.go
@@ -130,6 +130,7 @@ func ModifyAddressListWithAddrIDs(ctx context.Context, addressListId string, att
 	tx := global.GetInstance().GetDB().Begin()
 	addressListIds := []string{addressListId}
 	addrLists, err := GetAddressListsByIds(ctx, tx, addressListIds)
+	addrIds = stringutil.Unique(addrIds)
 	if len(addrLists) == 0 {
 		tx.Rollback()
 		err := gerr.New(ctx, gerr.NotFound, gerr.ErrorResourceNotExist, strings.Trim(fmt.Sprint(addressListIds), "[]"))


### PR DESCRIPTION
The main reason is that `addrIds` doesn't do deduplication.

after:

![image](https://user-images.githubusercontent.com/13731831/76252497-cf841880-6283-11ea-94ad-0ac4c284dd43.png)

![image](https://user-images.githubusercontent.com/13731831/76252543-e32f7f00-6283-11ea-8205-d93565236d65.png)
